### PR TITLE
Add automatic mixed precision training for ATME

### DIFF
--- a/models/atme_model.py
+++ b/models/atme_model.py
@@ -1,5 +1,6 @@
 import os
 import torch
+from torch.cuda.amp import GradScaler, autocast
 from .base_model import BaseModel
 from . import networks
 from util.image_pool import DiscPool
@@ -101,6 +102,9 @@ class AtmeModel(BaseModel):
             self.optimizers.append(self.optimizer_G)
             self.optimizers.append(self.optimizer_D)
 
+        self.use_amp = bool(getattr(opt, 'use_amp', False)) and self.isTrain and torch.cuda.is_available()
+        self.scaler = GradScaler(enabled=self.use_amp)
+
         self.save_noisy = True if opt.n_save_noisy > 0 else False
         if self.save_noisy:
             self.save_DW_idx = torch.randint(len(dataset), (opt.n_save_noisy,))
@@ -166,7 +170,6 @@ class AtmeModel(BaseModel):
         self.loss_D_real = self.criterionGAN(pred_real, True)
         # combine loss and calculate gradients
         self.loss_D = (self.loss_D_fake + self.loss_D_real) * 0.5
-        self.loss_D.backward()
 
     def backward_G(self):
         """Calculate GAN and L1 loss for the generator"""
@@ -178,20 +181,33 @@ class AtmeModel(BaseModel):
         self.loss_G_L1 = self.criterionL1(self.fake_B, self.real_B) * self.opt.lambda_L1
         # combine loss and calculate gradients
         self.loss_G = self.loss_G_GAN + self.loss_G_L1
-        self.loss_G.backward()
 
     def optimize_parameters(self):
-        self.forward()
+        with autocast(enabled=self.use_amp):
+            self.forward()
         # update D
         self.set_requires_grad(self.netD, True)
         self.optimizer_D.zero_grad()
-        self.backward_D()
-        self.optimizer_D.step()
+        with autocast(enabled=self.use_amp):
+            self.backward_D()
+        if self.use_amp:
+            self.scaler.scale(self.loss_D).backward()
+            self.scaler.step(self.optimizer_D)
+        else:
+            self.loss_D.backward()
+            self.optimizer_D.step()
         # update G
         self.set_requires_grad(self.netD, False)
         self.optimizer_G.zero_grad()
-        self.backward_G()
-        self.optimizer_G.step()
+        with autocast(enabled=self.use_amp):
+            self.backward_G()
+        if self.use_amp:
+            self.scaler.scale(self.loss_G).backward()
+            self.scaler.step(self.optimizer_G)
+            self.scaler.update()
+        else:
+            self.loss_G.backward()
+            self.optimizer_G.step()
         # Save discriminator output
         self.disc_pool.insert(self.disc_B.detach(), self.batch_indices)
         if self.save_noisy:  # Save images corresponding to disc_B and Disc_B

--- a/options/atme_options.py
+++ b/options/atme_options.py
@@ -61,5 +61,7 @@ class AtmeOptions(BaseOptions):
         parser.add_argument('--pool_size', type=int, default=50, help='the size of image buffer that stores previously generated images')
         parser.add_argument('--lr_policy', type=str, default='linear', help='learning rate policy. [linear | step | plateau | cosine]')
         parser.add_argument('--lr_decay_iters', type=int, default=50, help='multiply by a gamma every lr_decay_iters iterations')
+        parser.add_argument('--use_amp', default=True, action=argparse.BooleanOptionalAction,
+                            help='use automatic mixed precision for faster training when CUDA is available')
 
         return parser


### PR DESCRIPTION
## Summary
- enable optional automatic mixed precision in the ATME model using GradScaler to speed up training
- add a command-line flag to toggle AMP support for ATME runs

## Testing
- python -m compileall models/atme_model.py options/atme_options.py

------
https://chatgpt.com/codex/tasks/task_e_68d35ae1eeec83319cf61e547d8fb9ae