### PR TITLE
Fix DiscPool dtype mismatch for autocast outputs

### DIFF
--- a/util/image_pool.py
+++ b/util/image_pool.py
@@ -106,4 +106,9 @@ class DiscPool(Dataset):
             disc_out: output from the discriminator in the backward pass of generator
             img_idx: indices of the images that the discriminator just processed
         """
+        # torch.amp.autocast may produce half-precision discriminator outputs while the
+        # pool was initialized with float32 tensors.  Mixing these dtypes triggers a
+        # runtime error when updating the buffer, so we ensure both device and dtype
+        # match the pool storage before the assignment.
+        disc_out = disc_out.to(self.disc_out)
         self.disc_out[img_idx] = disc_out


### PR DESCRIPTION
## Summary
- ensure discriminator outputs inserted into the pool match the stored tensor dtype/device to avoid AMP-related runtime errors

## Testing
- python -m compileall util/image_pool.py

------
https://chatgpt.com/codex/tasks/task_e_68d36c6f49848331b688ca268d3254c1