### PR TITLE
Fix learning rate scheduler order

### DIFF
--- a/atme.py
+++ b/atme.py
@@ -59,7 +59,6 @@ def train(opt):
         iter_data_time = time.time()
         epoch_iter = 0
         visualizer.reset()
-        model.update_learning_rate()
         for i, data in enumerate(dataset):
             iter_start_time = time.time()
             if total_iters % opt.print_freq == 0:
@@ -106,6 +105,7 @@ def train(opt):
         visualizer.save_to_tensorboard_writer(epoch, losses)
 
         print('End of epoch %d / %d \t Time Taken: %d sec' % (epoch, opt.n_epochs + opt.n_epochs_decay, time.time() - epoch_start_time))
+        model.update_learning_rate(epoch)
 
 def test(opt):
     opt.isTrain = False

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -101,14 +101,29 @@ class BaseModel(ABC):
         """ Return image paths that are used to load current data"""
         return self.image_paths
 
-    def update_learning_rate(self):
+    def update_learning_rate(self, epoch=None):
         """Update learning rates for all the networks; called at the end of every epoch"""
         old_lr = self.optimizers[0].param_groups[0]['lr']
+        if epoch is not None:
+            # match the behaviour of stepping at the *start* of an epoch by
+            # offsetting the scheduler's epoch index. This keeps learning rate
+            # milestones identical to the previous implementation while
+            # allowing the update to happen after ``optimizer.step()`` has been
+            # called at least once.
+            scheduler_epoch = max(0, epoch - self.opt.epoch_count + 1)
+        else:
+            scheduler_epoch = None
         for scheduler in self.schedulers:
             if self.opt.lr_policy == 'plateau':
-                scheduler.step(self.metric)
+                if scheduler_epoch is None:
+                    scheduler.step(self.metric)
+                else:
+                    scheduler.step(self.metric, epoch=scheduler_epoch)
             else:
-                scheduler.step()
+                if scheduler_epoch is None:
+                    scheduler.step()
+                else:
+                    scheduler.step(scheduler_epoch)
 
         lr = self.optimizers[0].param_groups[0]['lr']
         print('learning rate %.7f -> %.7f' % (old_lr, lr))

--- a/simple.py
+++ b/simple.py
@@ -42,8 +42,6 @@ def train(opt):
         iter_data_time = time.time()
         epoch_iter = 0
         visualizer.reset()
-        if epoch > 1:
-            model.update_learning_rate()
         for i, data in enumerate(train_loader):
             iter_start_time = time.time()
             if total_iters % opt.print_freq == 0:
@@ -73,6 +71,7 @@ def train(opt):
         visualizer.save_to_tensorboard_writer(epoch, losses)
 
         print('End of epoch %d / %d \t Time Taken: %d sec' % (epoch, opt.n_epochs + opt.n_epochs_decay, time.time() - epoch_start_time))
+        model.update_learning_rate(epoch)
 
 def test(opt):
     opt.isTrain = False


### PR DESCRIPTION
## Summary
- update BaseModel.update_learning_rate to accept the current epoch and adjust scheduler stepping accordingly
- move learning rate updates in training loops to the end of each epoch so the optimizer steps precede scheduler steps

## Testing
- python -m compileall models/base_model.py simple.py atme.py

------
https://chatgpt.com/codex/tasks/task_e_68d371ef55708331b938ee60cd448348