### PR TITLE
Detach loss tensors before scalar conversion

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -126,7 +126,12 @@ class BaseModel(ABC):
         errors_ret = OrderedDict()
         for name in self.loss_names:
             if isinstance(name, str):
-                errors_ret[name] = float(getattr(self, 'loss_' + name))  # float(...) works for both scalar tensor and float number
+                loss_value = getattr(self, 'loss_' + name)
+                if isinstance(loss_value, torch.Tensor):
+                    # detach() avoids inadvertently keeping autograd history when converting tensors to scalars
+                    errors_ret[name] = loss_value.detach().item()
+                else:
+                    errors_ret[name] = float(loss_value)
         return errors_ret
 
     def save_networks(self, epoch):


### PR DESCRIPTION
## Summary
- detach loss tensors before turning them into Python scalars to avoid autograd warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3722afee88331b6ba57e6e95da664