### PR TITLE
Add training state checkpointing

### DIFF
--- a/atme.py
+++ b/atme.py
@@ -51,10 +51,12 @@ def train(opt):
     model = create_model(opt, dataset)
     model.setup(opt)
     visualizer = Visualizer(opt)
-    total_iters = 0
+    start_epoch = getattr(model, 'start_epoch', opt.epoch_count)
+    total_iters = getattr(model, 'start_iter', 0)
+    opt.epoch_count = start_epoch
 
 
-    for epoch in range(opt.epoch_count, opt.n_epochs + opt.n_epochs_decay + 1):
+    for epoch in range(start_epoch, opt.n_epochs + opt.n_epochs_decay + 1):
         epoch_start_time = time.time()
         iter_data_time = time.time()
         epoch_iter = 0
@@ -92,12 +94,14 @@ def train(opt):
                 visuals = model.get_current_visuals()
                 slice_num = i if opt.batch_size == 1 else random.randint(0, opt.batch_size)
                 save_atme_images(visuals, save_fig_dir, slice_num, iter_num=total_iters, epoch=epoch)
+                model.save_training_state(epoch, total_iters)
 
             iter_data_time = time.time()
         if epoch % opt.save_epoch_freq == 0:              # cache our model every <save_epoch_freq> epochs
             print('saving the model at the end of epoch %d, iters %d' % (epoch, total_iters))
             model.save_networks('latest')
             model.save_networks(epoch)
+            model.save_training_state(epoch + 1, total_iters)
 
         # Save D_real and D_fake
         visualizer.save_D_losses(model.get_current_losses())

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -42,6 +42,8 @@ class BaseModel(ABC):
         self.optimizers = []
         self.image_paths = []
         self.metric = 0  # used for learning rate policy 'plateau'
+        self.start_epoch = opt.epoch_count
+        self.start_iter = 0
 
     @abstractmethod
     def set_input(self, input):
@@ -74,6 +76,8 @@ class BaseModel(ABC):
         if not self.isTrain or opt.continue_train:
             load_suffix = 'iter_%d' % opt.load_iter if opt.load_iter > 0 else opt.epoch
             self.load_networks(load_suffix, pre_train_G_path=opt.pre_train_G_path)
+        if self.isTrain and opt.continue_train:
+            self.load_training_state()
 
 
     def eval(self):
@@ -164,6 +168,53 @@ class BaseModel(ABC):
                     net.cuda(self.gpu_ids[0])
                 else:
                     torch.save(net.state_dict(), save_path)
+
+    def save_training_state(self, epoch, total_iters):
+        """Save optimizer and scheduler states for resuming training later."""
+        if not self.isTrain:
+            return
+
+        state = {
+            'epoch': int(epoch),
+            'total_iters': int(total_iters),
+            'optimizer_states': [optimizer.state_dict() for optimizer in self.optimizers],
+        }
+
+        if hasattr(self, 'schedulers'):
+            state['scheduler_states'] = [scheduler.state_dict() for scheduler in getattr(self, 'schedulers', [])]
+
+        os.makedirs(self.save_dir, exist_ok=True)
+        save_path = os.path.join(self.save_dir, 'training_state.pth')
+        torch.save(state, save_path)
+
+    def load_training_state(self):
+        """Load optimizer and scheduler states to resume training."""
+        load_path = os.path.join(self.save_dir, 'training_state.pth')
+        if not os.path.isfile(load_path):
+            return
+
+        print('loading training state from %s' % load_path)
+        state = torch.load(load_path, map_location='cpu')
+
+        optimizer_states = state.get('optimizer_states', [])
+        if len(optimizer_states) != len(self.optimizers):
+            print('Warning: number of optimizers does not match when loading training state.')
+        for optimizer, opt_state in zip(self.optimizers, optimizer_states):
+            optimizer.load_state_dict(opt_state)
+            for opt_state_value in optimizer.state.values():
+                for k, v in opt_state_value.items():
+                    if isinstance(v, torch.Tensor):
+                        opt_state_value[k] = v.to(self.device)
+
+        if hasattr(self, 'schedulers'):
+            scheduler_states = state.get('scheduler_states', [])
+            if len(scheduler_states) != len(getattr(self, 'schedulers', [])):
+                print('Warning: number of schedulers does not match when loading training state.')
+            for scheduler, scheduler_state in zip(getattr(self, 'schedulers', []), scheduler_states):
+                scheduler.load_state_dict(scheduler_state)
+
+        self.start_epoch = state.get('epoch', self.start_epoch)
+        self.start_iter = state.get('total_iters', self.start_iter)
 
     def __patch_instance_norm_state_dict(self, state_dict, module, keys, i=0):
         """Fix InstanceNorm checkpoints incompatibility (prior to 0.4)"""

--- a/simple.py
+++ b/simple.py
@@ -30,14 +30,16 @@ def train(opt):
     train_loader = create_simple_train_dataset(opt)
     print('prepare data_loader done')
 
-    total_iters = 0
+    start_epoch = getattr(model, 'start_epoch', opt.epoch_count)
+    total_iters = getattr(model, 'start_iter', 0)
+    opt.epoch_count = start_epoch
 
     figures_path = os.path.join(opt.save_dir, 'figures', 'train')
     mkdir(figures_path)
 
     slice_index = int(opt.patch_size / 2)
 
-    for epoch in range(opt.epoch_count, opt.n_epochs + opt.n_epochs_decay + 1):
+    for epoch in range(start_epoch, opt.n_epochs + opt.n_epochs_decay + 1):
         epoch_start_time = time.time()
         iter_data_time = time.time()
         epoch_iter = 0
@@ -68,6 +70,7 @@ def train(opt):
             print('saving the model at the end of epoch %d, iters %d' % (epoch, total_iters))
             model.save_networks('latest')
             model.save_networks(epoch)
+            model.save_training_state(epoch + 1, total_iters)
 
         losses = model.get_current_losses()
         visualizer.save_to_tensorboard_writer(epoch, losses)


### PR DESCRIPTION
## Summary
- add BaseModel helpers to persist optimizer, scheduler, and progress metadata so training can resume after interruption
- update the simple and atme training loops to read the stored progress and write training state files when saving checkpoints

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d36c0c936c8331b0f109adb57368f6